### PR TITLE
Fix Markdown Heading Detection to Ignore `#` in Code Blocks

### DIFF
--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -208,23 +208,31 @@ def gh_wiki_cleanup():
 #     gh_wiki_cleanup()
 
 def heading_level(line):
-    hx = 0
-    for char in line.lstrip():
-        if char != "#":
-            return hx
-        hx+=1
-    return hx
+   hx = 0
+   for char in line.lstrip():
+       if char != "#":
+           return hx
+       hx+=1
+   return hx
+
 
 def fix_md_headings(md_content):
-    md_fixed = []
-    for l in md_content.splitlines():
-        hx = heading_level(l)
-        if hx > 0 and hx < 6:
-            l = "#"+l
-        elif hx >= 6:
-            logger.warning("h6 detected - could not be fixed using mkdocs hooks")
-        md_fixed.append(l)
-    return '\n'.join(md_fixed)
+   md_fixed = []
+   incode = False
+   for l in md_content.splitlines():
+       if (l.startswith("```")):
+           incode = not incode
+       if incode:
+           md_fixed.append(l)
+       else:
+           hx = heading_level(l)
+           if hx > 0 and hx < 6:
+               l = "#"+l
+           elif hx >= 6:
+               logger.warning("h6 detected - could not be fixed using mkdocs hooks")
+           md_fixed.append(l)
+   return '\n'.join(md_fixed)
+
 
 if __name__ == "__main__":
-    gh_wiki_cleanup()
+   gh_wiki_cleanup()


### PR DESCRIPTION


This update enhances the Markdown heading correction function by ensuring that `#` symbols within code blocks are ignored. Previously, the script would add an extra `#` to correct heading levels but also affected lines within code blocks, causing unintended modifications.

**Key Changes:**
- Added detection to ignore lines within code blocks (delimited by ```).
- Updated `fix_md_headings` to skip lines in code blocks while correcting Markdown heading levels outside of them.


