### PR TITLE
Improve feedback widget UX by adding auto-hide behavior

### DIFF
--- a/docs/javascripts/main.js
+++ b/docs/javascripts/main.js
@@ -103,70 +103,65 @@ function handlePopState() {
 }
 
 // Feedback
+
+// Feedback State Management
+const FeedbackState = {
+    INITIAL: 'initial',
+    SUBMITTED: 'submitted'
+};
+
 function initializeFeedback(selector) {
-    try {
-        const feedback = document.querySelector(selector);
-        if (!feedback) return;
+    const feedback = document.querySelector(selector);
+    if (!feedback) return;
 
-        const buttons = feedback.querySelectorAll('.md-feedback__icon:not(.md-feedback__contribute)');
-        const note = getFeedbackNote(feedback);
+    const buttons = feedback.querySelectorAll('.md-feedback__icon:not(.md-feedback__contribute)');
+    const feedbackContainer = feedback.querySelector('.md-feedback__inner');
+    const feedbackNote = feedback.querySelector('.md-feedback__note');
+    let currentState = FeedbackState.INITIAL;
 
-        buttons.forEach(button => {
-            button.addEventListener('click', () => handleFeedbackClick(button, buttons, note));
+    buttons.forEach(button => {
+        button.addEventListener('click', () => {
+            handleFeedbackClick(button, buttons, feedbackContainer, feedbackNote);
+            initializeContributeIcon(feedback);
         });
+    });
 
-        initializeContributeIcon(feedback);
-    } catch (error) {
-        console.error("Error in initializeFeedback:", error);
-    }
-}
-
-function getFeedbackNote(feedback) {
-    try {
-        let note = feedback.querySelector('.md-feedback__note');
-        if (!note) {
-            note = document.createElement('div');
-            note.className = 'md-feedback__note';
-            note.hidden = true;
-            feedback.querySelector('.md-feedback__inner').appendChild(note);
-        }
-        return note;
-    } catch (error) {
-        console.error("Error in getFeedbackNote:", error);
-        return null;
-    }
-}
-
-function handleFeedbackClick(button, allButtons, note) {
-    try {
+    function handleFeedbackClick(button, allButtons, container, note) {
         const data = button.getAttribute('data-md-value');
-        const url = `/${window.location.pathname}`;
-        const title = document.querySelector('.md-content__inner h1')?.textContent || '';
+        
+   
 
-        console.log(`Feedback: ${data} for page ${url} (${title})`);
-
-        note.textContent = `Thank you for your feedback!`;
-        note.hidden = false;
-
+        // Disable all buttons
         allButtons.forEach(btn => btn.disabled = true);
-    } catch (error) {
-        console.error("Error in handleFeedbackClick:", error);
+
+        // Show thank you message using existing note element
+        if (note) {
+            note.textContent = 'Thank you for your feedback!';
+            note.hidden = false;
+        }
+        
+        // Fade out and hide feedback after delay
+        setTimeout(() => {
+            feedback.classList.add('md-feedback--fade-out');
+            setTimeout(() => {
+                feedback.style.display = 'none';
+            }, 100);
+        }, 1000);
     }
 }
 
 function initializeContributeIcon(feedback) {
-    try {
-        const contributeIcon = feedback.querySelector('.md-feedback__contribute');
-        const contributeNote = feedback.querySelector('.md-feedback__contribute-note');
+    const contributeIcon = feedback.querySelector('.md-feedback__contribute');
+    const contributeNote = feedback.querySelector('.md-feedback__contribute-note');
 
-        if (contributeIcon && contributeNote) {
-            contributeIcon.addEventListener('mouseenter', () => contributeNote.hidden = false);
-            contributeIcon.addEventListener('mouseleave', () => contributeNote.hidden = true);
-        }
-    } catch (error) {
-        console.error("Error in initializeContributeIcon:", error);
+    if (contributeIcon && contributeNote) {
+        contributeIcon.addEventListener('mouseenter', () => contributeNote.hidden = false);
+        contributeIcon.addEventListener('mouseleave', () => contributeNote.hidden = true);
     }
 }
+
+
+
 
 // Collapse 
 function handleSearchPageCollapse() {

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -115,7 +115,7 @@
 
 .md-nav--secondary {
   flex: 1;
-  margin-bottom: 5rem;
+  margin-bottom: 5.5rem;
 }
 
 .keywords-cloud-container {

--- a/docs/stylesheets/feedback.css
+++ b/docs/stylesheets/feedback.css
@@ -3,16 +3,15 @@
 }
 .md-feedback,
 .md-nav__feedback {
-  padding: 1rem;
-  margin-top: 1rem;
-  border-top: 1px solid var(--md-default-fg-color--lightest);
+  padding: 0.1rem;
+
 }
 
 .md-feedback p,
 .md-nav__feedback p {
-  margin: 0 0 0.5rem;
+  margin: 0 0 0.1rem;
   font-weight: 700;
-  font-size: 0.8rem;
+  font-size: 0.7rem;
   color: var(--md-default-fg-color--light);
 }
 
@@ -20,7 +19,7 @@
 .md-nav__feedback .md-feedback__inner {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
 }
 .md-feedback__inner--fade-out {
   opacity: 0;
@@ -28,25 +27,8 @@
   transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
-.md-feedback__indicator {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 8px;
-  border-radius: 4px;
-  background-color: #fff;
-  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
-  margin-top: 8px;
-}
 
-.md-feedback__indicator.hidden {
-  display: none;
-}
 
-.md-feedback__indicator i {
-  margin-right: 8px;
-  font-size: 16px;
-}
 
 .feedback-success {
   color: #45a049;
@@ -77,7 +59,6 @@
 .md-feedback__icon,
 .md-nav__feedback .md-feedback__icon {
   margin-right: 0.5rem;
-  padding: 0.25rem;
   background: none;
   border: none;
   cursor: pointer;
@@ -113,9 +94,9 @@
     display: block;
     position: fixed;
     bottom: 4%;
+
     background-color: var(--md-default-bg-color);
-    box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
-      0 4px 6px -2px rgba(0, 0, 0, 0.05);
+
     border-radius: 0.2rem;
   }
 

--- a/docs/stylesheets/feedback.css
+++ b/docs/stylesheets/feedback.css
@@ -22,6 +22,50 @@
   flex-direction: column;
   align-items: flex-start;
 }
+.md-feedback__inner--fade-out {
+  opacity: 0;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.md-feedback__indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
+  border-radius: 4px;
+  background-color: #fff;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+  margin-top: 8px;
+}
+
+.md-feedback__indicator.hidden {
+  display: none;
+}
+
+.md-feedback__indicator i {
+  margin-right: 8px;
+  font-size: 16px;
+}
+
+.feedback-success {
+  color: #45a049;
+}
+
+.feedback-neutral {
+  color: #666;
+}
+
+.md-feedback--fade-out {
+  opacity: 0;
+  transform: translateY(-10px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.feedback-text {
+  font-size: 12px;
+  color: #666;
+}
 
 .md-feedback__list,
 .md-nav__feedback .md-feedback__list {

--- a/overrides/base.html
+++ b/overrides/base.html
@@ -206,40 +206,96 @@
                 {% if config.extra.analytics %}
                 {% set feedback = config.extra.analytics.feedback %}
                 {% if feedback %}
-                  <div class="md-nav__feedback md-nav__feedback--desktop">
-                    <p class="feedback-title">{{ feedback.title }}</p>
-                    <div class="md-feedback__inner">
-                      <div class="md-feedback__list">
-                        {% for rating in feedback.ratings %}
-                          <button class="md-feedback__icon md-icon" title="{{ rating.name }}" data-md-value="{{ rating.data }}">
-                            {% include ".icons/" ~ rating.icon ~ ".svg" %}
-                          </button>
-                        {% endfor %}
-                        <a href="https://github.com/gpac/wiki/issues" class="md-feedback__icon md-icon md-feedback__contribute" title="Contribute to this page" target="_blank">
-                          {% include ".icons/material/plus-circle.svg" %}
-                        </a>
+                <div class="md-nav__feedback md-nav__feedback--desktop">
+                  <form class="md-feedback" name="feedback" hidden>
+                    <fieldset>
+                      <legend class="md-feedback__title">
+                        {{ feedback.title }}
+                      </legend>
+                      <div class="md-feedback__inner">
+                        <div class="md-feedback__list">
+                          {% for rating in feedback.ratings %}
+                            <button 
+                              class="md-feedback__icon md-icon" 
+                              type="submit" 
+                              title="{{ rating.name }}" 
+                              data-md-value="{{ rating.data }}"
+                            >
+                              {% include ".icons/" ~ rating.icon ~ ".svg" %}
+                            </button>
+                          {% endfor %}
+                          <a href="https://github.com/gpac/wiki/issues" 
+                             class="md-feedback__icon md-icon md-feedback__contribute" 
+                             title="Contribute to this page" 
+                             target="_blank"
+                          >
+                            {% include ".icons/material/plus-circle.svg" %}
+                          </a>
+                        </div>
+                        <div class="md-feedback__note">
+                          {% for rating in feedback.ratings %}
+                            <div data-md-value="{{ rating.data }}" hidden>
+                              {{ rating.note }}
+                              {% if not rating.note %}
+                                Thanks for your feedback!
+                              {% endif %}
+                            </div>
+                          {% endfor %}
+                          <div class="md-feedback__contribute-note" hidden>
+                            Contribute to improve this page
+                          </div>
+                        </div>
                       </div>
-                      <div class="md-feedback__note" hidden></div>
-                    </div>
-                  </div>
-                  <div class="md-feedback md-feedback--mobile">
-                    <p>{{ feedback.title }}</p>
-                    <div class="md-feedback__inner">
-                      <div class="md-feedback__list">
-                        {% for rating in feedback.ratings %}
-                          <button class="md-feedback__icon md-icon" title="{{ rating.name }}" data-md-value="{{ rating.data }}">
-                            {% include ".icons/" ~ rating.icon ~ ".svg" %}
-                          </button>
-                        {% endfor %}
-                        <a href="https://github.com/gpac/wiki/issues" class="md-feedback__icon md-icon md-feedback__contribute" title="Contribute to this page" target="_blank">
-                          {% include ".icons/material/plus-circle.svg" %}
-                        </a>
+                    </fieldset>
+                  </form>
+                </div>
+            
+                {# Mobile feedback section - same structure #}
+                <div class="md-feedback md-feedback--mobile">
+                  <form class="md-feedback" name="feedback" hidden>
+                    <fieldset>
+                      <legend class="md-feedback__title">
+                        {{ feedback.title }}
+                      </legend>
+                      <div class="md-feedback__inner">
+                        <div class="md-feedback__list">
+                          {% for rating in feedback.ratings %}
+                            <button 
+                              class="md-feedback__icon md-icon" 
+                              type="submit" 
+                              title="{{ rating.name }}" 
+                              data-md-value="{{ rating.data }}"
+                            >
+                              {% include ".icons/" ~ rating.icon ~ ".svg" %}
+                            </button>
+                          {% endfor %}
+                          <a href="https://github.com/gpac/wiki/issues" 
+                             class="md-feedback__icon md-icon md-feedback__contribute" 
+                             title="Contribute to this page" 
+                             target="_blank"
+                          >
+                            {% include ".icons/material/plus-circle.svg" %}
+                          </a>
+                        </div>
+                        <div class="md-feedback__note">
+                          {% for rating in feedback.ratings %}
+                            <div data-md-value="{{ rating.data }}" hidden>
+                              {{ rating.note }}
+                              {% if not rating.note %}
+                                Thanks for your feedback!
+                              {% endif %}
+                            </div>
+                          {% endfor %}
+                          <div class="md-feedback__contribute-note" hidden>
+                            Contribute to improve this page
+                          </div>
+                        </div>
                       </div>
-                      <div class="md-feedback__note" hidden></div>
-                    </div>
-                  </div>
-                {% endif %}
+                    </fieldset>
+                  </form>
+                </div>
               {% endif %}
+            {% endif %}
               </div>
             {% endif %}
           {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,10 +1,69 @@
-{#-
-    This file was automatically generated - do not edit
-  -#}
-  {% extends "base.html" %}
+{#- 
+  This file is an override of the original base.html 
+  It includes only custom blocks. Do not edit the original base.html directly. 
+-#}
 
-  {% block content %}
-  <article class="md-content__inner md-typeset">
-    {{ page.content }}
-  </article>
+{% extends "base.html" %}
+
+{# Block Scripts: Ajout de vos scripts personnalisés #}
+{% block scripts %}
+  <script src="{{ 'assets/javascripts/bundle.83f73b43.min.js' | url }}"></script>
+  <script type="module" src="{{ 'javascripts/main.js' | url }}"></script>
+  {% for script in config.extra_javascript %}
+    {{ script | script_tag }}
+  {% endfor %}
+{% endblock %}
+
+{# Block Styles: Ajout de vos feuilles de style personnalisées #}
+{% block styles %}
+  <link rel="stylesheet" href="{{ 'assets/stylesheets/main.0253249f.min.css' | url }}">
+  {% if config.theme.palette %}
+    {% set palette = config.theme.palette %}
+    <link rel="stylesheet" href="{{ 'assets/stylesheets/palette.06af60db.min.css' | url }}">
+  {% endif %}
+  {% include "partials/icons.html" %}
+{% endblock %}
+
+{# Block Config: Ajout ou modification de configuration JSON #}
+{% block config %}
+  {%- set app = {
+    "base": base_url,
+    "features": features,
+    "translations": {},
+    "search": "assets/javascripts/workers/search.6ce7567c.min.js" | url
+  } -%}
+  {%- if config.extra.version -%}
+    {%- set mike = config.plugins.get("mike") -%}
+    {%- if not mike or mike.config.version_selector -%}
+      {%- set _ = app.update({ "version": config.extra.version }) -%}
+    {%- endif -%}
+  {%- endif -%}
+  {%- if config.extra.tags -%}
+    {%- set _ = app.update({ "tags": config.extra.tags }) -%}
+  {%- endif -%}
+  {%- set translations = app.translations -%}
+  {%- for key in [
+    "clipboard.copy",
+    "clipboard.copied",
+    "search.result.placeholder",
+    "search.result.none",
+    "search.result.one",
+    "search.result.other",
+    "search.result.more.one",
+    "search.result.more.other",
+    "search.result.term.missing",
+    "select.version"
+  ] -%}
+    {%- set _ = translations.update({ key: lang.t(key) }) -%}
+  {%- endfor -%}
+  <script id="__config" type="application/json">
+    {{- app | tojson -}}
+  </script>
+{% endblock %}
+
+{# Block Content: Personnalisation de la zone de contenu principal si nécessaire #}
+{% block content %}
+<article class="md-content__inner md-typeset">
+  {{ page.content }}
+</article>
 {% endblock %}

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,11 +1,5 @@
-{#- 
-  This file is an override of the original base.html 
-  It includes only custom blocks. Do not edit the original base.html directly. 
--#}
-
 {% extends "base.html" %}
 
-{# Block Scripts: Ajout de vos scripts personnalisés #}
 {% block scripts %}
   <script src="{{ 'assets/javascripts/bundle.83f73b43.min.js' | url }}"></script>
   <script type="module" src="{{ 'javascripts/main.js' | url }}"></script>
@@ -14,7 +8,6 @@
   {% endfor %}
 {% endblock %}
 
-{# Block Styles: Ajout de vos feuilles de style personnalisées #}
 {% block styles %}
   <link rel="stylesheet" href="{{ 'assets/stylesheets/main.0253249f.min.css' | url }}">
   {% if config.theme.palette %}
@@ -24,7 +17,6 @@
   {% include "partials/icons.html" %}
 {% endblock %}
 
-{# Block Config: Ajout ou modification de configuration JSON #}
 {% block config %}
   {%- set app = {
     "base": base_url,
@@ -61,7 +53,6 @@
   </script>
 {% endblock %}
 
-{# Block Content: Personnalisation de la zone de contenu principal si nécessaire #}
 {% block content %}
 <article class="md-content__inner md-typeset">
   {{ page.content }}

--- a/overrides/partials/feedback.html
+++ b/overrides/partials/feedback.html
@@ -1,50 +1,96 @@
-<!-- {#-
+ {#-
     This file was automatically generated - do not edit
 -#}
-{% if config.extra.analytics %}
-  {% set feedback = config.extra.analytics.feedback %}
-{% endif %}
-{% if page.meta and page.meta.hide %}
-  {% if "feedback" in page.meta.hide %}
-    {% set feedback = None %}
-  {% endif %}
-{% endif %}
-{% if feedback %}
-  <form class="md-feedback" name="feedback" hidden>
-    <fieldset>
-      <legend class="md-feedback__title">
-        {{ feedback.title }}
-      </legend>
-      <div class="md-feedback__inner">
-        <div class="md-feedback__list">
-          {% for rating in feedback.ratings %}
-            <button class="md-feedback__icon md-icon" type="submit" title="{{ rating.name }}" data-md-value="{{ rating.data }}">
-              {% include ".icons/" ~ rating.icon ~ ".svg" %}
-            </button>
-          {% endfor %}
-          <!-- Contribute icon -->
-<!--           <a href="https://github.com/gpac/wiki/issues" target="_blank" class="md-feedback__icon md-icon md-feedback__contribute" title="Contribute to this page">
-            {% include ".icons/material/plus-circle.svg" %}
-          </a>
-        </div>
-        <div class="md-feedback__note">
-          {% for rating in feedback.ratings %}
-            <div data-md-value="{{ rating.data }}" hidden>
-              {% set url = "/" ~ page.url %}
-              {% if page.meta and page.meta.title %}
-                {% set title = page.meta.title | urlencode %}
-              {% else %}
-                {% set title = page.title | urlencode %}
+     {% if config.extra.analytics %}
+                {% set feedback = config.extra.analytics.feedback %}
+                {% if feedback %}
+                <div class="md-nav__feedback md-nav__feedback--desktop">
+                  <form class="md-feedback" name="feedback" hidden>
+                    <fieldset>
+                      <legend class="md-feedback__title">
+                        {{ feedback.title }}
+                      </legend>
+                      <div class="md-feedback__inner">
+                        <div class="md-feedback__list">
+                          {% for rating in feedback.ratings %}
+                            <button 
+                              class="md-feedback__icon md-icon" 
+                              type="submit" 
+                              title="{{ rating.name }}" 
+                              data-md-value="{{ rating.data }}"
+                            >
+                              {% include ".icons/" ~ rating.icon ~ ".svg" %}
+                            </button>
+                          {% endfor %}
+                          <a href="https://github.com/gpac/wiki/issues" 
+                             class="md-feedback__icon md-icon md-feedback__contribute" 
+                             title="Contribute to this page" 
+                             target="_blank"
+                          >
+                            {% include ".icons/material/plus-circle.svg" %}
+                          </a>
+                        </div>
+                        <div class="md-feedback__note">
+                          {% for rating in feedback.ratings %}
+                            <div data-md-value="{{ rating.data }}" hidden>
+                              {{ rating.note }}
+                              {% if not rating.note %}
+                                Thanks for your feedback!
+                              {% endif %}
+                            </div>
+                          {% endfor %}
+                          <div class="md-feedback__contribute-note" hidden>
+                            Contribute to improve this page
+                          </div>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </form>
+                </div>
+            
+                {# Mobile feedback section#}
+                <div class="md-feedback md-feedback--mobile">
+                  <form class="md-feedback" name="feedback" hidden>
+                    <fieldset>
+                      <legend class="md-feedback__title">
+                        {{ feedback.title }}
+                      </legend>
+                      <div class="md-feedback__inner">
+                        <div class="md-feedback__list">
+                          {% for rating in feedback.ratings %}
+                            <button 
+                              class="md-feedback__icon md-icon" 
+                              type="submit" 
+                              title="{{ rating.name }}" 
+                              data-md-value="{{ rating.data }}"
+                            >
+                              {% include ".icons/" ~ rating.icon ~ ".svg" %}
+                            </button>
+                          {% endfor %}
+                          <a href="https://github.com/gpac/wiki/issues" 
+                             class="md-feedback__icon md-icon md-feedback__contribute" 
+                             title="Contribute to this page" 
+                             target="_blank"
+                          >
+                            {% include ".icons/material/plus-circle.svg" %}
+                          </a>
+                        </div>
+                        <div class="md-feedback__note">
+                          {% for rating in feedback.ratings %}
+                            <div data-md-value="{{ rating.data }}" hidden>
+                              {{ rating.note }}
+                              {% if not rating.note %}
+                                Thanks for your feedback!
+                              {% endif %}
+                            </div>
+                          {% endfor %}
+                          <div class="md-feedback__contribute-note" hidden>
+                            Contribute to improve this page
+                          </div>
+                        </div>
+                      </div>
+                    </fieldset>
+                  </form>
+                </div>
               {% endif %}
-              {{ rating.note.format(url = url, title = title) }}
-            </div>
-          {% endfor %}
-          <!-- Contribute note -->
-<!--           <div class="md-feedback__contribute-note" hidden>
-            Contribute to improve this page
-          </div>
-        </div>
-      </div>
-    </fieldset>
-  </form>
-{% endif %} --> <!-- --> 
+            {% endif %}


### PR DESCRIPTION
# Fixes #27 - Feedback dialog blocking sidebar access
Resolves https://github.com/gpac/wiki/issues/27

## Description
This PR addresses the issue where the feedback dialog remains visible after submission, preventing users from accessing the end of the sidebar on some pages(for example https://wiki.gpac.io/Filters/filters_general)

## Changes
- Made feedback widget auto-hide after submission
- Minimized widget vertical footprint with horizontal layout
## Before/After
### Before
- Feedback dialog remained visible after submission
- Dialog blocked access to bottom sidebar items
- Large vertical space consumption

### After
- Dialog automatically disappears after feedback submission
- Full sidebar accessibility restored
