### PR TITLE
Update glossary links 

### DIFF
--- a/docs/glossary/source.md
+++ b/docs/glossary/source.md
@@ -53,7 +53,6 @@ gpac -i input.mp4 -o output.mp4
 - **options**: Additional parameters to control the behavior of the source filter (e.g., loop, start time).
   
 ## See Also
-- [Input](input)
-- [Filter](filter.md)
+
 - [Decoder](decoder.md)
 

--- a/docs/javascripts/modalFunctions.js
+++ b/docs/javascripts/modalFunctions.js
@@ -51,7 +51,7 @@ function setModalContent(modalTitle, modalDefinition, modalLink, keyword, defini
       descriptionText = definition.description;
     }
 
-    const glossaryPageUrl = `${window.location.origin}/glossary//`;
+    const glossaryPageUrl = `${window.location.origin}/glossary/${keyword.toLowerCase()}`;
     const tagsPageUrl = `/tags/#${keyword.toLowerCase()}`;
 
     modalTitle.textContent = keyword;


### PR DESCRIPTION
- Removal of obsolete links in the glossary  to avoid unnecessary warnings.
- Corrected glossary URL generation to dynamically include the lower-case keyword, ensuring link functionality.
