### PR TITLE
Add "Edit this page", keep generated pages read-only

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,14 @@
 site_name: GPAC wiki
 site_url: https://wiki.gpac.io/
+repo_name: gpac/wiki
+edit_uri: edit/master/docs/
 site_author: GPAC contributors
 extra:
   keywords_file: 'data/keywords.json'
+  social:
+  - icon: fontawesome/brands/github
+    link: https://github.com/gpac/gpac
+    name: GPAC source code
 extra_javascript:
    - javascripts/levels.js
    - javascripts/main.js
@@ -52,6 +58,7 @@ theme:
     - navigation.top
     - tables
     - def_list
+    - content.action.edit
     - content.code.select
     - content.code.annotate
     - content.code.copy
@@ -64,7 +71,7 @@ theme:
     - search.highlight
     - search.share
     - search.suggest
-repo_url: https://github.com/gpac/gpac/
+repo_url: https://github.com/gpac/wiki
 plugins:
   - search
   - tags:

--- a/overrides/base.html
+++ b/overrides/base.html
@@ -303,7 +303,7 @@
             <div class="md-content" data-md-component="content">
               <article class="md-content__inner md-typeset">
  {% set p = page and page.file and page.file.src_path %}
-{% if page and page.edit_url and not page.is_homepage and not (p and (p.startswith('Filters/') or p.startswith('MP4Box/') or p.startswith('/'))) %}
+{% if page and page.edit_url and not page.is_homepage and not (p and (p.startswith('Filters/') or p.startswith('MP4Box/'))) %}
   {% include "partials/actions.html" %}
 {% endif %}
                 {% block content %}

--- a/overrides/base.html
+++ b/overrides/base.html
@@ -302,6 +302,10 @@
           {% block container %}
             <div class="md-content" data-md-component="content">
               <article class="md-content__inner md-typeset">
+ {% set p = page and page.file and page.file.src_path %}
+{% if page and page.edit_url and not page.is_homepage and not (p and (p.startswith('Filters/') or p.startswith('MP4Box/') or p.startswith('/'))) %}
+  {% include "partials/actions.html" %}
+{% endif %}
                 {% block content %}
                   {% include "partials/content.html" %}
                 {% endblock %}

--- a/overrides/partials/header.html
+++ b/overrides/partials/header.html
@@ -69,9 +69,15 @@
         {% include "partials/source.html" %}
       </div>
     {% endif %}
-   <!--  <div class="md-header__option md-header__option--mobile">
-      {% include "partials/palette.html" %}
-    </div> -->
+<a href="https://github.com/gpac/gpac"
+   class="md-header__button md-icon"
+   title="GPAC source code"
+   aria-label="GPAC source code"
+   target="_blank" rel="noopener">
+ <i class="fa-brands fa-github" style="font-size:1rem; line-height:1.5; margin-top:0.5rem !important;"></i>
+   <div class="gpac-link__label">gpac</div>
+</a>
+
     <div class="md-header__settings">
       <button class="md-header__settings-button" aria-label="Settings" title="Settings"> 
         <i class="fas fa-cog"></i>


### PR DESCRIPTION
- Enable in-browser edits via MkDocs Material .
- Hide edit button on Filters/, MP4Box/ and homepage .
- Keep a clear header link to gpac/gpac ; repo_url now points to gpac/wiki.