### PR TITLE
Fix file extension in DASH segment generation example

### DIFF
--- a/docs/Howtos/dash/DASH-basics.md
+++ b/docs/Howtos/dash/DASH-basics.md
@@ -110,7 +110,7 @@ You now know how to create a compliant DASH content from a given file, but what 
 
 ```
 MP4Box -dash 10000 -segment-name mysegs_%s -url-template
-         -out final.mpd file1.mp4 ... fileN.mp
+         -out final.mpd file1.mp4 ... fileN.mp4
 ```
 
 ## Playback


### PR DESCRIPTION
Fixed a small typo in the code example `.mp` -> `.mp4`
Sorry if this sounds like being petty, but for me that would be sort of annoying to look at.